### PR TITLE
Feat/conta bonus

### DIFF
--- a/dim0517-banco-backend/app/Http/Controllers/ContaController.php
+++ b/dim0517-banco-backend/app/Http/Controllers/ContaController.php
@@ -17,14 +17,14 @@ class ContaController extends Controller
 
     public function store(Request $request)
     {
-        $aux = $this->contaService->criarConta($request->conta);
+        $aux = $this->contaService->criarConta($request->conta, $request->tipo);
         
         if($aux->status() == 200){
             return redirect()->route('formLogin')->with(['mensagem' => 'Conta criada com sucesso']);
         }
         
         if($aux->status() == 400) {
-            return redirect()->back()->with(['mensagem' => 'Conta já existe']);
+            return redirect()->back()->with(['mensagem' => $aux->original["mensagem"]]);
         }
 
         return redirect()->back()->with(['mensagem' => 'Erro ao criar conta']);

--- a/dim0517-banco-backend/app/Models/Conta.php
+++ b/dim0517-banco-backend/app/Models/Conta.php
@@ -10,6 +10,8 @@ class Conta extends Model
     protected $fillable = [
         'conta',
         'saldo',
+        'tipo',
+        'pontos'
     ];
 
     // Cast saldo as decimal with 2 decimal places

--- a/dim0517-banco-backend/app/Services/ContaService.php
+++ b/dim0517-banco-backend/app/Services/ContaService.php
@@ -12,16 +12,24 @@ class ContaService
         $this->contaModel = $contaModel;
     }
 
-    public function criarConta(int $conta)
+    public function criarConta(int $conta, string $tipo)
     {
+        if ($tipo != 'bonus' && $tipo != 'tradicional') {
+            return response()->json(['message' => 'Tipo de conta inválido'], 400);
+        }
+
         $contaExistente = $this->contaModel->where('conta', $conta)->first();
         if ($contaExistente) {
             return response()->json(['message' => 'Conta já existente'], 400);
         }
 
+        $pontos = ($tipo == 'bonus') ? 10 : 0;
+
         DB::table('contas')->insert([
             'conta' => $conta,
             'saldo' => 0,
+            'tipo' => $tipo,
+            'pontos' => $pontos,
         ]);
         
         return response()->json(['message' => 'Conta criada com sucesso'], 200);

--- a/dim0517-banco-backend/app/Services/ContaService.php
+++ b/dim0517-banco-backend/app/Services/ContaService.php
@@ -70,6 +70,10 @@ class ContaService
 
         $contaExistente->saldo += $valor;
 
+        if ($contaExistente->tipo == 'bonus') {
+            $contaExistente->pontos += intdiv($valor, 100);
+        }
+
         DB::table('contas')->where('conta', $conta)->update(['saldo' => $contaExistente->saldo]);
         return response()->json(['mensagem' => 'Valor adicionado com sucesso', 'conta' => $contaExistente], 200);
     }
@@ -89,8 +93,15 @@ class ContaService
         }
 
         $conta2Existente->saldo += $valor;
+        $updateData = ['saldo' => $conta2Existente->saldo];
 
-        DB::table('contas')->where('conta', $conta)->update(['saldo' => $contaExistente->saldo]);
+        if ($conta2Existente->tipo == 'bonus') {
+            $conta2Existente->pontos += intdiv($valor, 200);
+            $updateData['pontos'] = $conta2Existente->pontos;
+        }
+
+
+        DB::table('contas')->where('conta', $conta)->update($updateData);
         DB::table('contas')->where('conta', $conta2)->update(['saldo' => $conta2Existente->saldo]);
         return response()->json(['mensagem' => 'Valor transferido com sucesso', 'conta' => $contaExistente, 'conta2' => $conta2Existente], 200);
     }

--- a/dim0517-banco-backend/database/factories/ContaFactory.php
+++ b/dim0517-banco-backend/database/factories/ContaFactory.php
@@ -12,6 +12,8 @@ class ContaFactory extends Factory
         return [
             'conta' => fake()->unique()->randomNumber(5),
             'saldo' => number_format(fake()->randomFloat(2, -1000, 1000), 2, '.', ''),
+            'tipo' => fake()->randomElement(['bonus', 'tradicional']),
+            'pontos' => fake()->randomNumber(2),
         ];
     }
 }

--- a/dim0517-banco-backend/database/migrations/2025_05_17_223701_create_conta_table.php
+++ b/dim0517-banco-backend/database/migrations/2025_05_17_223701_create_conta_table.php
@@ -15,6 +15,8 @@ return new class extends Migration
             $table->id();
             $table->unsignedBigInteger('conta');
             $table->decimal('saldo', 15,2);
+            $table->string('tipo');
+            $table->integer('pontos');
         });
     }
 

--- a/dim0517-banco-backend/resources/views/createAccount.blade.php
+++ b/dim0517-banco-backend/resources/views/createAccount.blade.php
@@ -110,11 +110,20 @@
     <form action="{{route('store')}}" method="post" enctype="application/x-www-form-urlencoded">
         @csrf
         <h1 class="h3 mb-3 fw-normal">Seja bem vindo</h1>
-        <div class="form-floating">
-            <input type="number" min='0' step='1' class="form-control" id="floatingInput" name="conta" placeholder="Numero da conta" required>
-            <label for="floatingInput">Número da conta</label>
+        <div>
+            <label for="conta">Nova conta</label>
+            <input type="number" min='0' step='1' class="form-control" id="conta" name="conta" placeholder="Numero da conta" required>
         </div>
-        
+        <hr>
+        <div>
+            <label for="floatingInput">Tipo da conta</label>
+            <select class="form-select" name="tipo" id="floatingSelect" aria-label="Floating label select example" required>
+                <option selected>Escolha o tipo</option>
+                <option value="bonus">Bonus</option>
+                <option value="tradicional">Tradicional</option>
+            </select>
+        </div>
+        <hr>
         <button class="btn btn-primary w-100 py-2" type="submit">Criar</button>
         <p class="mt-5 mb-3 text-body-secondary">&copy; 2017–2025</p>
         @if (session()->has('mensagem'))


### PR DESCRIPTION
Introduce new fields 'tipo' and 'pontos' to the Conta model, migration, factory, and service. Update the create account form to allow selecting the account type. Bonus accounts are initialized with 10 points, while traditional accounts start with 0.

Introduce logic to calculate and update bonus points for accounts of type 'bonus' when adding or transferring values. Points are calculated based on the transaction amount, with different rates for adding and transferring values.